### PR TITLE
Implement custom morelikethis request

### DIFF
--- a/api/morelikethis.py
+++ b/api/morelikethis.py
@@ -68,7 +68,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                 method="GET",
                 url=f"{endpoint}/indexes/{index_name}/docs",
                 params={
-                    "api-version": "2023-11-01",
+                    "api-version": "2024-05-01-preview",
                     "moreLikeThis": page_id,
                     "top": 5,
                     "count": "true"

--- a/api/morelikethis.py
+++ b/api/morelikethis.py
@@ -62,24 +62,21 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         logging.info(f"/MoreLikeThis page_id = {page_id}")
         
         try:
-            # Create the request body for the More Like This query
-            request_body = {
-                "search": "",
-                "moreLikeThis": page_id,
-                "top": 5,
-                "count": True
-            }
-            
-            # Create the HTTP request for the search endpoint
+            # Create the HTTP request for the MoreLikeThis query
+            # MoreLikeThis uses GET request to /docs endpoint with moreLikeThis as query parameter
             request = HttpRequest(
-                method="POST",
-                url=f"{endpoint}/indexes/{index_name}/docs/search",
-                params={"api-version": "2023-11-01"},
+                method="GET",
+                url=f"{endpoint}/indexes/{index_name}/docs",
+                params={
+                    "api-version": "2023-11-01",
+                    "moreLikeThis": page_id,
+                    "top": 5,
+                    "count": "true"
+                },
                 headers={
                     "Content-Type": "application/json",
                     "api-key": key
-                },
-                content=json.dumps(request_body)
+                }
             )
             
             # Send the request using the search client's send_request method


### PR DESCRIPTION
Fix MoreLikeThis tab error by directly calling Azure Search REST API for 'more like this' functionality.

The `search_client.search()` method does not support the `more_like_this` parameter, leading to the "Failed to load similar articles" error. This PR implements the functionality by constructing a direct GET request to the Azure Search `/docs` endpoint with the `moreLikeThis` query parameter and using `search_client.send_request()` with API version `2024-05-01-preview`.